### PR TITLE
Add missing aria-orientation attribute to role=toolbar

### DIFF
--- a/.changeset/new-pets-agree.md
+++ b/.changeset/new-pets-agree.md
@@ -1,0 +1,5 @@
+---
+"html-aria": patch
+---
+
+Add missing aria-orientation attribute to toolbar

--- a/src/lib/aria-roles.ts
+++ b/src/lib/aria-roles.ts
@@ -732,7 +732,7 @@ export const documentRoles: Record<DocumentStructureRole, RoleData> = {
     superclasses: ['group'],
     nameRequired: false,
     required: [],
-    supported: ['aria-activedescendant', 'aria-atomic', 'aria-braillelabel', 'aria-brailleroledescription', 'aria-busy', 'aria-controls', 'aria-current', 'aria-describedby', 'aria-description', 'aria-details', 'aria-disabled', 'aria-dropeffect', 'aria-flowto', 'aria-grabbed', 'aria-hidden', 'aria-keyshortcuts', 'aria-label', 'aria-labelledby', 'aria-live', 'aria-owns', 'aria-relevant', 'aria-roledescription'], // biome-ignore format: long list
+    supported: ['aria-activedescendant', 'aria-atomic', 'aria-braillelabel', 'aria-brailleroledescription', 'aria-busy', 'aria-controls', 'aria-current', 'aria-describedby', 'aria-description', 'aria-details', 'aria-disabled', 'aria-dropeffect', 'aria-flowto', 'aria-grabbed', 'aria-hidden', 'aria-keyshortcuts', 'aria-label', 'aria-labelledby', 'aria-live', 'aria-orientation', 'aria-owns', 'aria-relevant', 'aria-roledescription'], // biome-ignore format: long list
     prohibited: [],
     elements: [
       { tagName: 'menu', attributes: { role: 'toolbar' } },

--- a/test/get-supported-attributes.test.ts
+++ b/test/get-supported-attributes.test.ts
@@ -135,7 +135,7 @@ const tests: [
   ],
   ['dialog', { given: [{ tagName: 'dialog' }], want: [...GLOBAL_ATTRIBUTES, ...roles.dialog.supported] }],
   ['div', { given: [{ tagName: 'div' }], want: GENERIC_NO_NAMING }],
-  ['div', { given: [{ tagName: 'div', attributes: { role: 'button' } }], want: BUTTON_ATTRIBUTES }],
+  ['div[role=button]', { given: [{ tagName: 'div', attributes: { role: 'button' } }], want: BUTTON_ATTRIBUTES }],
   ['dl', { given: [{ tagName: 'dl' }], want: GLOBAL_ATTRIBUTES }],
   ['dt', { given: [{ tagName: 'dt' }], want: GLOBAL_ATTRIBUTES }],
   ['em', { given: [{ tagName: 'em' }], want: GENERIC_NO_NAMING }],


### PR DESCRIPTION
## Changes

Fixes accidental missing `aria-orientation` attribute to `role=toolbar`

## How to Review

This is really hard to test for, and was just a minor data issue

## Checklist

- [ ] Unit tests updated
