### PR TITLE
fix: role for aside element when nested within sectioning content

### DIFF
--- a/.changeset/purple-trees-serve.md
+++ b/.changeset/purple-trees-serve.md
@@ -2,4 +2,4 @@
 "html-aria": patch
 ---
 
-Fix role for aside element when nested within landmark
+Fix role for aside element when nested within sectioning content

--- a/.changeset/purple-trees-serve.md
+++ b/.changeset/purple-trees-serve.md
@@ -1,0 +1,5 @@
+---
+"html-aria": patch
+---
+
+Fix role for aside element when nested within landmark

--- a/src/get-role.ts
+++ b/src/get-role.ts
@@ -1,6 +1,7 @@
-import { ALL_ROLES, roles } from './lib/aria-roles.js';
+import { ALL_ROLES } from './lib/aria-roles.js';
 import { NO_CORRESPONDING_ROLE, tags } from './lib/html.js';
 import { calculateAccessibleName, firstMatchingToken, isEmptyAncestorList, virtualizeElement } from './lib/util.js';
+import { getAsideRole } from './tags/aside.js';
 import { getFooterRole } from './tags/footer.js';
 import { getHeaderRole } from './tags/header.js';
 import { getInputRole } from './tags/input.js';
@@ -55,6 +56,10 @@ export function getRole(element: VirtualElement | HTMLElement, options?: GetRole
     case 'a':
     case 'area': {
       return attributes && !('href' in attributes) ? 'generic' : tag.defaultRole;
+    }
+    case 'aside': {
+      const name = calculateAccessibleName({ tagName, attributes });
+      return name ? tag.defaultRole : getAsideRole(options);
     }
     case 'header': {
       return getHeaderRole(options);

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,11 +1,4 @@
-import type {
-  ARIAAttribute,
-  AncestorList,
-  AttributeData,
-  NameProhibitedAttributes,
-  TagName,
-  VirtualElement,
-} from '../types.js';
+import type { ARIAAttribute, AncestorList, NameProhibitedAttributes, TagName, VirtualElement } from '../types.js';
 
 /** Parse a list of roles, e.g. role="graphics-symbol img" */
 export function parseTokenList(tokenList: string): string[] {
@@ -62,6 +55,12 @@ export function calculateAccessibleName(element: VirtualElement): string | undef
   const { tagName, attributes } = element;
 
   switch (tagName) {
+    case 'aside': {
+      /**
+       * @see https://www.w3.org/TR/html-aam-1.0/#section-and-grouping-element-accessible-name-computation
+       */
+      return (attributes?.['aria-label'] || attributes?.['aria-labelledby']) as string;
+    }
     case 'img': {
       /**
        * According to spec, aria-label is technically allowed for <img> (even if alt is preferred)

--- a/src/tags/aside.ts
+++ b/src/tags/aside.ts
@@ -1,0 +1,22 @@
+import { tags } from '../lib/html.js';
+import { firstMatchingAncestor } from '../lib/util.js';
+import type { AncestorList } from '../types.js';
+
+function hasSectioningContentParent(ancestors: AncestorList) {
+  return !!firstMatchingAncestor(
+    [
+      { tagName: 'article', attributes: { role: 'article' } },
+      { tagName: 'aside', attributes: { role: 'complementary' } },
+      { tagName: 'nav', attributes: { role: 'navigation' } },
+      { tagName: 'section', attributes: { role: 'region' } },
+    ],
+    ancestors,
+  );
+}
+
+export function getAsideRole({ ancestors }: { ancestors?: AncestorList } = {}) {
+  if (!ancestors) {
+    return tags.aside.defaultRole;
+  }
+  return hasSectioningContentParent(ancestors) ? 'generic' : tags.aside.defaultRole;
+}

--- a/test/get-role.test.ts
+++ b/test/get-role.test.ts
@@ -31,6 +31,56 @@ describe('getRole', () => {
     ['area (no href)', { given: [{ tagName: 'area', attributes: {} }], want: 'generic' }],
     ['article', { given: [{ tagName: 'article' }], want: 'article' }],
     ['aside', { given: [{ tagName: 'aside' }], want: 'complementary' }],
+    [
+      'aside (name, sectioning article)',
+      {
+        given: [
+          { tagName: 'aside', attributes: { 'aria-label': 'My aside' } },
+          { ancestors: [{ tagName: 'article' }] },
+        ],
+        want: 'complementary',
+      },
+    ],
+    [
+      'aside (name, sectioning aside)',
+      {
+        given: [{ tagName: 'aside', attributes: { 'aria-label': 'My aside' } }, { ancestors: [{ tagName: 'aside' }] }],
+        want: 'complementary',
+      },
+    ],
+    [
+      'aside (name, sectioning nav)',
+      {
+        given: [{ tagName: 'aside', attributes: { 'aria-label': 'My aside' } }, { ancestors: [{ tagName: 'nav' }] }],
+        want: 'complementary',
+      },
+    ],
+    [
+      'aside (name, sectioning section)',
+      {
+        given: [
+          { tagName: 'aside', attributes: { 'aria-label': 'My aside' } },
+          { ancestors: [{ tagName: 'section' }] },
+        ],
+        want: 'complementary',
+      },
+    ],
+    [
+      'aside (no name, sectioning article)',
+      { given: [{ tagName: 'aside' }, { ancestors: [{ tagName: 'article' }] }], want: 'generic' },
+    ],
+    [
+      'aside (no name, sectioning aside)',
+      { given: [{ tagName: 'aside' }, { ancestors: [{ tagName: 'aside' }] }], want: 'generic' },
+    ],
+    [
+      'aside (no name, sectioning nav)',
+      { given: [{ tagName: 'aside' }, { ancestors: [{ tagName: 'nav' }] }], want: 'generic' },
+    ],
+    [
+      'aside (no name, sectioning section)',
+      { given: [{ tagName: 'aside' }, { ancestors: [{ tagName: 'section' }] }], want: 'generic' },
+    ],
     ['audio', { given: [{ tagName: 'audio' }], want: undefined }],
     ['b', { given: [{ tagName: 'b' }], want: 'generic' }],
     ['base', { given: [{ tagName: 'base' }], want: undefined }],


### PR DESCRIPTION
## Changes

Relates to #25

Updates the role returned for a `aside` element to be either:

1. `complementary` when the element is named;
2. `complementary` when the element is not nested within [sectioning content](https://html.spec.whatwg.org/multipage/dom.html#sectioning-content);
3. `generic` otherwise.

This detail is currently missing from the [HTML-ARIA](https://www.w3.org/TR/html-aria/#el-aside) spec, but is describe in the sibling HTML-AAM spec:

- https://www.w3.org/TR/html-aam-1.0/#el-aside-ancestorbodymain - when scoped to `body` or `main` (i.e. not sectioning content)
- https://www.w3.org/TR/html-aam-1.0/#el-aside - when scoped to sectioning content

## How to Review

Mirrors the existing functionality and tests for combination of the `img` element which has similar named behaviours, and the `footer` which has similar scoping/nesting behaviours.

Undecided whether would be cleaner to scope the `calculateAccessibleName()` check within the new `getAsideRole()` - perhaps feels a bit awkward to have a `getAsideRole()` that holds partial logic for getting the role, the rest living elsewhere 🤔 wdyt?

Starting to see patterns arising, e.g. `attributes['aria-label'] || attributes['aria-labelledby']` repeated, but perhaps still borderline rule or 3 to warrant refactoring at this stage?

## Checklist

- [x] Unit tests updated
