### PR TITLE
spike: benchmark against dom-accessibility-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@changesets/cli": "^2.27.12",
     "@types/aria-query": "^5.0.4",
     "aria-query": "^5.3.2",
+    "dom-accessibility-api": "^0.7.0",
     "jsdom": "^25.0.1",
     "typescript": "^5.7.3",
     "unbuild": "^3.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       aria-query:
         specifier: ^5.3.2
         version: 5.3.2
+      dom-accessibility-api:
+        specifier: ^0.7.0
+        version: 0.7.0
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -845,6 +848,9 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.7.0:
+    resolution: {integrity: sha512-LjjdFmd9AITAet3Hy6Y6rwB7Sq1+x5NiwbOpnkLHC1bCXJqJKiV9DyppSSWobuSKvjKXt9G2u3hW402MPt6m+g==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2610,6 +2616,8 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dom-accessibility-api@0.7.0: {}
 
   dom-serializer@2.0.0:
     dependencies:

--- a/test/html-aria.bench.ts
+++ b/test/html-aria.bench.ts
@@ -1,8 +1,9 @@
 import { elementRoles } from 'aria-query';
+import { getRole as domAccessibilityApiGetRole } from 'dom-accessibility-api';
 import { bench, describe } from 'vitest';
 import { getRole } from '../src/index.js';
 
-describe('getRole', () => {
+describe('getRole (virtual)', () => {
   bench('html-aria', () => {
     getRole({ tagName: 'input', attributes: { type: 'checkbox' } });
   });
@@ -12,5 +13,18 @@ describe('getRole', () => {
       name: 'input',
       attributes: [{ name: 'type', value: 'checkbox' }],
     });
+  });
+});
+
+describe('getRole (HTMLElement)', () => {
+  const element = document.createElement('input');
+  element.type = 'checkbox';
+
+  bench('html-aria', () => {
+    getRole(element);
+  });
+
+  bench('dom-accessibility-api', () => {
+    domAccessibilityApiGetRole(element);
   });
 });


### PR DESCRIPTION
## Changes

Adds a benchmark for passing an `HTMLElement` to `getRole()` vs the equivalent method supported by [`dom-accessibility-api`](https://github.com/eps1lon/dom-accessibility-api).

```
 ✓ test/html-aria.bench.ts > getRole (HTMLElement) 1960ms
     name                             hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · html-aria                730,807.38  0.0012  0.3561  0.0014  0.0013  0.0015  0.0017  0.0051  ±0.45%   365404
   · dom-accessibility-api  4,422,801.23  0.0001  0.3841  0.0002  0.0002  0.0003  0.0003  0.0008  ±0.72%  2211401   fastest

 BENCH  Summary

  dom-accessibility-api - test/html-aria.bench.ts > getRole (HTMLElement)
    6.05x faster than html-aria
```

The current process of virtualizing (normalizing?) `HTMLElement` inputs comes at some overhead compared to this similar library. Depending on whether best in class for performance when handling elements is an aim, it _might_ be worth considering removing the virtualization layer and interacting with the element directly, at the cost of branching code to handle the virtual and "real" cases separately in internals.

## How to Review

This is more for visibility than something that necessarily needs merging.

Feel free to close if not interested in benchmarking against this library.

## Checklist

- [x] Unit tests updated
